### PR TITLE
Implement singleton on repositories

### DIFF
--- a/lib/data/repositories/event_repository.dart
+++ b/lib/data/repositories/event_repository.dart
@@ -6,9 +6,16 @@ import 'package:http/http.dart' as http;
 import 'package:flutter_buddies/data/models/event.dart';
 
 class EventRepository {
+  static final EventRepository _eventRepository = EventRepository._();
   List<Event> _events = [];
 
-  static EventRepository get() => EventRepository();
+  static EventRepository get() => _eventRepository;
+
+  factory EventRepository() {
+    return _eventRepository;
+  }
+
+  EventRepository._();
 
   // TODO
   Future<List<Event>> fetchAll({bool fresh: false}) async {
@@ -37,7 +44,16 @@ class EventRepository {
   }
 }
 
-class FakeEventRepository extends EventRepository {
+class FakeEventRepository implements EventRepository {
+  final EventRepository _delegate;
+
+  List<Event> get _events => _delegate._events;
+  set _events(value) => _delegate._events = value;
+
+  FakeEventRepository() : _delegate = EventRepository();
+
+  Future<List<Event>> take([int count = 4]) => _delegate.take();
+
   @override
   Future<List<Event>> fetchAll({bool fresh: false}) async {
     int eventsNumber = 10;

--- a/lib/data/repositories/project_repository.dart
+++ b/lib/data/repositories/project_repository.dart
@@ -4,9 +4,16 @@ import 'package:http/http.dart' as http;
 import 'package:flutter_buddies/data/models/project.dart';
 
 class ProjectRepository {
+  static final ProjectRepository _projectRepository = ProjectRepository._();
   List<Project> _projects = [];
 
-  static ProjectRepository get() => ProjectRepository();
+  static ProjectRepository get() => _projectRepository;
+
+  factory ProjectRepository() {
+    return _projectRepository;
+  }
+
+  ProjectRepository._();
 
   Future<List<Project>> fetchAll({bool fresh: false}) async {
     if (_projects.isEmpty || fresh) {
@@ -36,7 +43,17 @@ class ProjectRepository {
   }
 }
 
-class FakeProjectRepository extends ProjectRepository {
+class FakeProjectRepository implements ProjectRepository {
+  final ProjectRepository _delegate;
+
+  List<Project> get _projects => _delegate._projects;
+  set _projects(value) => _delegate._projects = value;
+
+  FakeProjectRepository() : _delegate = ProjectRepository();
+
+  Future<List<Project>> take([int count = 3]) => _delegate.take();
+  Future<List<Project>> takeAll() => _delegate.takeAll();
+
   @override
   Future<List<Project>> fetchAll({bool fresh: false}) async {
     int projectsNumber = 10;


### PR DESCRIPTION
I have implemented the singleton pattern on both repositories. Pay attention that to be able to implement it, the Fake Repositories are now implementing the standard Repositories instead of extending them as there is now a factory in place of a parameterless constructor. And so I had to use a delegate to call the not overridden methods.